### PR TITLE
fix: pending wallet address copy issue fixed

### DIFF
--- a/packages/uiweb/src/lib/components/chat/ChatProfile/PendingMembers.tsx
+++ b/packages/uiweb/src/lib/components/chat/ChatProfile/PendingMembers.tsx
@@ -123,7 +123,7 @@ export const PendingMembers = ({
                     icon: item?.userInfo?.profile?.picture || null,
                     chatId: null,
                     web3Name: null,
-                    recipient: shortenText(pCAIP10ToWallet(item.address?.split(':')[1]), 6, true),
+                    recipient: pCAIP10ToWallet(item.address?.split(':')[1]),
                     abbrRecipient: shortenText(pCAIP10ToWallet(item.address?.split(':')[1]), 6, true),
                     desc: null,
                   }}
@@ -313,8 +313,8 @@ export const AcceptedMembers = ({
               isAdmin(item) && accountStatus?.role === GROUP_ROLES.ADMIN.toLowerCase()
                 ? [removeAdminDropdown, removeMemberDropdown]
                 : accountStatus?.role === GROUP_ROLES.ADMIN.toLowerCase()
-                ? [addAdminDropdown, removeMemberDropdown]
-                : []
+                  ? [addAdminDropdown, removeMemberDropdown]
+                  : []
             }
             selectedMemberAddress={selectedMemberAddress}
             setSelectedMemberAddress={setSelectedMemberAddress}
@@ -375,7 +375,7 @@ const PendingSection = styled.div`
   box-sizing: border-box;
 `;
 
-const ArrowImage = styled(Image)<ShadowedProps>`
+const ArrowImage = styled(Image) <ShadowedProps>`
   margin-left: auto;
   transform: ${(props) => (props?.setPosition ? 'rotate(0)' : 'rotate(180deg)')};
 `;
@@ -390,7 +390,7 @@ const Badge = styled.div`
   font-weight: 700;
 `;
 
-const ProfileSection = styled(Section)<{ theme: IChatTheme }>`
+const ProfileSection = styled(Section) <{ theme: IChatTheme }>`
   height: fit-content;
   &::-webkit-scrollbar-thumb {
     background: transparent;


### PR DESCRIPTION
When copying pending wallet address in the group info, only half of the wallet address was getting copied

#1297 

## Fixes Issue
Closes: #1297 

## Changes proposed

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

0x9D964e3F0336acAB0AD2bA496a2Cb0cC5079F493 -> full wallet address gets copied
<img width="1470" alt="Screenshot 2024-05-28 at 5 40 07 PM" src="https://github.com/push-protocol/push-sdk/assets/77395788/e6582836-8ccf-4d28-9649-a49d37a9c9ee">

