### PR TITLE
SDK-1416: Update and Handle messageType for GIFs as MediaEmbed

### DIFF
--- a/packages/uiweb/src/lib/components/chat/ChatViewBubbleCore/CardRenderer.tsx
+++ b/packages/uiweb/src/lib/components/chat/ChatViewBubbleCore/CardRenderer.tsx
@@ -98,7 +98,7 @@ export const CardRenderer = ({
       )}
 
       {/* Gif Card */}
-      {chat.messageType === 'GIF' && (
+      {(chat.messageType === 'GIF' || chat.messageType === 'MediaEmbed') && (
         <GIFCard
           chat={chat}
           background={

--- a/packages/uiweb/src/lib/components/chat/MessageInput/MessageInput.tsx
+++ b/packages/uiweb/src/lib/components/chat/MessageInput/MessageInput.tsx
@@ -419,7 +419,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   };
 
   const sendGIF = async (emojiObject: GIFType) => {
-    sendPushMessage(emojiObject.url as string, 'GIF');
+    sendPushMessage(emojiObject.url as string, 'MediaEmbed');
     setGifOpen(false);
   };
 
@@ -751,7 +751,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   );
 };
 
-const TypebarSection = styled(Section) <{ border?: string }>`
+const TypebarSection = styled(Section)<{ border?: string }>`
   // gap: 10px;
   border: ${(props) => props.border || 'none'};
   @media ${device.mobileL} {


### PR DESCRIPTION

- Pass `messageType` as "MediaEmbed" for GIF media in `MessageInput`.
- Update `CardRenderer` to display GIF cards for both `messageType` values: "GIF" and "MediaEmbed".
